### PR TITLE
Enable drag-and-drop editing

### DIFF
--- a/src/components/craftnodes.tsx
+++ b/src/components/craftnodes.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { useNode } from "@craftjs/core";
+import { Button, Typography, Card, Form, Input, Select } from "antd";
+
+export const DragContainer: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <div ref={(ref) => ref && connect(drag(ref))}>{children}</div>
+  );
+};
+DragContainer.craft = { displayName: "Container" };
+
+export const DragCard: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <Card ref={(ref) => ref && connect(drag(ref))}>{children}</Card>
+  );
+};
+DragCard.craft = { displayName: "Card" };
+
+export const DragButton: React.FC<{ text?: string }> = ({ text }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <Button ref={(ref) => ref && connect(drag(ref))}>{text || "Button"}</Button>
+  );
+};
+DragButton.craft = { displayName: "Button" };
+
+export const DragText: React.FC<{ text?: string }> = ({ text }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <Typography.Text ref={(ref) => ref && connect(drag(ref))}>
+      {text || "Text"}
+    </Typography.Text>
+  );
+};
+DragText.craft = { displayName: "Text" };
+
+export const DragInputField: React.FC<{ label: string; name: any }> = ({ label, name }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <div ref={(ref) => ref && connect(drag(ref))}>
+      <Form.Item label={label} name={name}>
+        <Input />
+      </Form.Item>
+    </div>
+  );
+};
+DragInputField.craft = { displayName: "InputField" };
+
+export const DragSelectField: React.FC<{ label: string; name: any; options: { label: string; value: any }[] }> = ({ label, name, options }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <div ref={(ref) => ref && connect(drag(ref))}>
+      <Form.Item label={label} name={name}>
+        <Select options={options} />
+      </Form.Item>
+    </div>
+  );
+};
+DragSelectField.craft = { displayName: "SelectField" };
+

--- a/src/components/crafttoolbox.tsx
+++ b/src/components/crafttoolbox.tsx
@@ -1,27 +1,49 @@
-// components/Toolbox.js
 import React from "react";
-import { Card, Typography, Grid, Button } from "antd";
+import { Card, Typography, Button } from "antd";
+import { useEditor } from "@craftjs/core";
+import {
+  DragButton,
+  DragText,
+  DragContainer,
+  DragCard,
+  DragInputField,
+  DragSelectField,
+} from "./craftnodes";
 
 export const Toolbox = () => {
+  const { connectors } = useEditor();
   return (
-    <Card>
+    <Card style={{ marginBottom: 24 }}>
       <div>
-        <div>
-          <Typography>Drag to add</Typography>
-        </div>
-        <div>
+        <Typography style={{ marginBottom: 8 }}>Drag to add</Typography>
+        <div ref={(ref) => ref && connectors.create(ref, <DragButton text="Button" />)}>
           <Button>Button</Button>
         </div>
-        <div>
+        <div ref={(ref) => ref && connectors.create(ref, <DragText text="Text" />)}>
           <Button>Text</Button>
         </div>
-        <div>
+        <div ref={(ref) => ref && connectors.create(ref, <DragContainer />)}>
           <Button>Container</Button>
         </div>
-        <div>
+        <div ref={(ref) => ref && connectors.create(ref, <DragCard />)}>
           <Button>Card</Button>
         </div>
+        <div ref={(ref) => ref && connectors.create(ref, <DragInputField label="Input" name="newInput" />)}>
+          <Button>Input</Button>
+        </div>
+        <div ref={(ref) =>
+            ref &&
+            connectors.create(
+              ref,
+              <DragSelectField
+                label="Select"
+                name="newSelect"
+                options={[{ label: "Option", value: "1" }]}
+              />
+            )
+          }>
+          <Button>Select</Button>
+        </div>
       </div>
-    </Card>
-  )
+    </Card>  );
 };

--- a/src/pages/posts/edit.tsx
+++ b/src/pages/posts/edit.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-
 import { Edit, useForm, useSelect } from "@refinedev/antd";
-
-import { Form, Input, Select } from "antd";
-
+import { Form } from "antd";
+import { Editor, Frame, Element } from "@craftjs/core";
+import { Toolbox } from "../../components/crafttoolbox";
+import {
+  DragContainer,
+  DragInputField,
+  DragSelectField,
+} from "../../components/craftnodes";
 import type { IPost, ICategory } from "../../interfaces";
 
 export const PostEdit = () => {
@@ -17,66 +21,31 @@ export const PostEdit = () => {
 
   return (
     <Edit saveButtonProps={saveButtonProps}>
-      <Form {...formProps} layout="vertical">
-        <Form.Item
-          label="Title"
-          name="title"
-          rules={[
-            {
-              required: true,
-            },
-          ]}
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item
-          label="Category"
-          name={["category", "id"]}
-          rules={[
-            {
-              required: true,
-            },
-          ]}
-        >
-          <Select {...categorySelectProps} />
-        </Form.Item>
-        <Form.Item
-          label="Status"
-          name="status"
-          rules={[
-            {
-              required: true,
-            },
-          ]}
-        >
-          <Select
-            options={[
-              {
-                label: "Published",
-                value: "published",
-              },
-              {
-                label: "Draft",
-                value: "draft",
-              },
-              {
-                label: "Rejected",
-                value: "rejected",
-              },
-            ]}
-          />
-        </Form.Item>
-        <Form.Item
-          label="Content"
-          name="content"
-          rules={[
-            {
-              required: true,
-            },
-          ]}
-        >
-        </Form.Item>
-      </Form>
+      <Toolbox />
+      <Editor resolver={{ DragContainer, DragInputField, DragSelectField }}>
+        <Frame>
+          <Element is={DragContainer} canvas>
+            <Form {...formProps} layout="vertical">
+              <DragInputField label="Title" name="title" />
+              <DragSelectField
+                label="Category"
+                name={["category", "id"]}
+                options={categorySelectProps.options || []}
+              />
+              <DragSelectField
+                label="Status"
+                name="status"
+                options={[
+                  { label: "Published", value: "published" },
+                  { label: "Draft", value: "draft" },
+                  { label: "Rejected", value: "rejected" },
+                ]}
+              />
+              <DragInputField label="Content" name="content" />
+            </Form>
+          </Element>
+        </Frame>
+      </Editor>
     </Edit>
   );
 };


### PR DESCRIPTION
## Summary
- add craft nodes for drag-and-drop elements
- update toolbox to use Craft.js connectors
- wrap edit form with Craft.js editor so components can be rearranged

## Testing
- `npm run build` *(fails: Cannot find module '@refinedev/core' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d8118c7f8832cae3e168976e5adcd